### PR TITLE
Replace proxy-peer-address handler with forwarded handler in the description of  proxy-peer-address handler

### DIFF
--- a/src/main/asciidoc/predicates-attributes-handlers.asciidoc
+++ b/src/main/asciidoc/predicates-attributes-handlers.asciidoc
@@ -632,7 +632,7 @@ The headers that are read are:
 * `X-Forwarded-Host`
 * `X-Forwarded-Port`
 
-In general either this handler or `proxy-peer-address` handler should be used, they should not both
+In general either this handler or `forwarded` handler should be used, they should not both
 be installed at once.
 
 === Redirect Handler


### PR DESCRIPTION
In the description of **proxy-forwarded-address handler**, the last sentence contains "**this handler or proxy-forwarded-address handler**", which refers to the same handler instead of "**forwarded**" handler